### PR TITLE
Mixin MixinPlayerRenderer.class only for client

### DIFF
--- a/src/main/resources/slashblade.mixins.json
+++ b/src/main/resources/slashblade.mixins.json
@@ -1,7 +1,10 @@
 {
   "package": "mods.flammpfeil.slashblade.mixin",
   "mixins": [
-    "MixinPacketBuffer","MixinPlayerRenderer","MixinBlockBehaviour"
+    "MixinPacketBuffer","MixinBlockBehaviour"
+  ],
+  "client": [
+    "MixinPlayerRenderer"
   ],
   "refmap": "slashblade.refmap.json",
   "required": true,


### PR DESCRIPTION
When SlashBlade runs on server, the mixins will cause an exception and print a stack trace, because the render class is only in client.
This change to slashblade.mixins.json is not necessary, but it's better to make the server console cleaner.

=w=